### PR TITLE
feat: add link to snaefell nft from nav bar

### DIFF
--- a/public/locales/en/header.json
+++ b/public/locales/en/header.json
@@ -47,6 +47,10 @@
                     "url": "https://trailblazers.taiko.xyz/", 
                     "icon": "/img/icons/nav-trailblazer.svg" 
                 }, { 
+                    "name": "Snaefell NFT",
+                    "url": "https://snaefellnft.taiko.xyz/",
+                    "icon": "/img/icons/nav-trailblazer.svg"
+                }, {
                     "name": "Blog", 
                     "url": "/blog", 
                     "icon": "/img/icons/nav-blog.svg" 


### PR DESCRIPTION
I'm reusing the trailblazers icon as there is no icon for snaefell NFT. @je4nt0nic do we need one?